### PR TITLE
[7] remove poetry.lock

### DIFF
--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -85,7 +85,9 @@ jobs:
       #----------------------------------------------      
       - name: Delete poetry.lock file
         if: ${{ inputs.delete-poetry-lock }}
-        run: rm ./poetry.lock
+        run: |
+          rm ./poetry.lock
+          echo "::Warning tile=poetry.lock::Poetry.lock is deleted in this workflow run. You might have to do this too when reproducing build errors."
 
       #----------------------------------------------
       #       install Python

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: string
         default: .
+      delete-poetry-lock:
+        description: Delete poetry lock file in order to test against newer versions
+        required: false
+        type: boolean
+        default: false
 
 
 jobs:
@@ -74,6 +79,13 @@ jobs:
       #       check out repo
       #----------------------------------------------
       - uses: actions/checkout@v4
+
+      #----------------------------------------------
+      #       delete poetry.lock file in order to run tests against newer versions
+      #----------------------------------------------      
+      - name: Delete poetry.lock file
+        if: ${{ inputs.delete-poetry-lock }}
+        run: rm ./poetry.lock
 
       #----------------------------------------------
       #       install Python


### PR DESCRIPTION
closes #7 

Tried this out with runzi and already found a build error  - albeit caused by a newer `flake8` version.

When the `poetry.lock` file is removed, we write a warning message to avoid confusion when trying to reproduce build errors:

![image](https://github.com/user-attachments/assets/7c71d136-725f-4a9f-a0ec-0883b8d25f99)
