### PR TITLE
[9] Slack notifications

### DIFF
--- a/.github/workflows/python-run-tests-test.yml
+++ b/.github/workflows/python-run-tests-test.yml
@@ -17,5 +17,4 @@ jobs:
       python-versions:  "['3.10']" # "['3.9', '3.10', '3.11']"
       working-directory: samplePythonProject
       fail-on-codecov-error: false
-      slack-error: true
     secrets: inherit

--- a/.github/workflows/python-run-tests-test.yml
+++ b/.github/workflows/python-run-tests-test.yml
@@ -13,8 +13,8 @@ jobs:
   call-test-workflow:
     uses: ./.github/workflows/python-run-tests.yml
     with:
-      operating-systems: "['ubuntu-latest', 'macos-latest', 'windows.latest']"
-      python-versions:  "['3.9', '3.10', '3.11']"
+      operating-systems: "['ubuntu-latest']" #"['ubuntu-latest', 'macos-latest', 'windows.latest']"
+      python-versions:  "['3.10']" # "['3.9', '3.10', '3.11']"
       working-directory: samplePythonProject
       fail-on-codecov-error: false
     secrets: inherit

--- a/.github/workflows/python-run-tests-test.yml
+++ b/.github/workflows/python-run-tests-test.yml
@@ -8,12 +8,16 @@ on:
   # schedules this to run weekly
   schedule:
     - cron: '5 3 * * 0' # At 03:05 on Sunday
+  push:
+    branches: [main, pre-release]
+  pull_request:
+    branches: [main, pre-release]    
 
 jobs:
   call-test-workflow:
     uses: ./.github/workflows/python-run-tests.yml
     with:
-      operating-systems: "['ubuntu-latest', 'macos-latest', 'windows.latest']"
+      operating-systems: "['ubuntu-latest', 'macos-latest', 'windows-latest']"
       python-versions:  "['3.9', '3.10', '3.11']"
       working-directory: samplePythonProject
       fail-on-codecov-error: false

--- a/.github/workflows/python-run-tests-test.yml
+++ b/.github/workflows/python-run-tests-test.yml
@@ -13,8 +13,8 @@ jobs:
   call-test-workflow:
     uses: ./.github/workflows/python-run-tests.yml
     with:
-      operating-systems: "['ubuntu-latest']" #"['ubuntu-latest', 'macos-latest', 'windows.latest']"
-      python-versions:  "['3.10']" # "['3.9', '3.10', '3.11']"
+      operating-systems: "['ubuntu-latest', 'macos-latest', 'windows.latest']"
+      python-versions:  "['3.9', '3.10', '3.11']"
       working-directory: samplePythonProject
       fail-on-codecov-error: false
     secrets: inherit

--- a/.github/workflows/python-run-tests-test.yml
+++ b/.github/workflows/python-run-tests-test.yml
@@ -17,4 +17,5 @@ jobs:
       python-versions:  "['3.10']" # "['3.9', '3.10', '3.11']"
       working-directory: samplePythonProject
       fail-on-codecov-error: false
+      slack-error: true
     secrets: inherit

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -181,4 +181,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "⚠️*${{ job.status }}*\n[${{ github.event.repository.name }}, ${{ matrix.os }}, Python ${{ matrix.python-version }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job }})"
+            text: "⚠️*${{ job.status }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.event.repository.name }}, ${{ matrix.os }}, Python ${{ matrix.python-version }}>"

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -75,6 +75,19 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
     steps:
 
+      - name: Post a message in a channel
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "*GitHub Action build result*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"      
+
       #----------------------------------------------
       #       check out repo
       #----------------------------------------------

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -53,11 +53,6 @@ on:
         required: false
         type: boolean
         default: false
-      slack-error:
-        description: Post error message to Slack on build failure
-        required: false
-        type: boolean
-        default: false
 
 
 jobs:
@@ -172,11 +167,11 @@ jobs:
           fail_ci_if_error: ${{ inputs.fail-on-codecov-error }}
 
       #----------------------------------------------
-      #       Post error msg to Slack
+      #       Post error msg to Slack for failed scheduled builds
       #----------------------------------------------        
       - name: Post a Slack message if build failed
         uses: slackapi/slack-github-action@v2.0.0
-        if: failure()
+        if: failure() && github.event_name == 'schedule' 
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -10,6 +10,7 @@ name: Run Python Tests
 # See default values for examples. This is because reusable workflows cannot take arrays as arguments.
 #
 # Set up the SCHEDULED_GITHUB_SLACK_WEBHOOK secret to receive Slack notification of build failures of scheduled runs.
+# Messages will be posted to the `cwg-scheduled-builds` channel: https://nshmrevisionproject.slack.com/archives/C08QYS2ER9T
  
 
 on:

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -81,7 +81,7 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "*GitHub Action build result*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+            text: "*${{ github.event.repository.name }}*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
 
       #----------------------------------------------
       #       check out repo

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -8,6 +8,8 @@ name: Run Python Tests
 # 
 # Matrix arrays `operating-systems` and `python-versions` are required and need to be provided as stringified JSON. 
 # See default values for examples. This is because reusable workflows cannot take arrays as arguments.
+#
+# Set up the SCHEDULED_GITHUB_SLACK_WEBHOOK secret to receive Slack notification of build failures of scheduled runs.
  
 
 on:
@@ -173,7 +175,7 @@ jobs:
         uses: slackapi/slack-github-action@v2.0.0
         if: failure() && github.event_name == 'schedule' 
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SCHEDULED_GITHUB_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
             text: "⚠️*${{ job.status }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.event.repository.name }}, ${{ matrix.os }}, Python ${{ matrix.python-version }}>"

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -181,4 +181,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "⚠️*${{ github.event.repository.name }}*: ${{ job.status }}\n${{ matrix.os }}, Python ${{ matrix.python-version }}"          
+            text: "⚠️*${{ github.event.repository.name }}*: ${{ job.status }}\n${{ matrix.os }}, Python ${{ matrix.python-version }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -81,7 +81,6 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "*GitHub Action build result*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
             blocks:
               - type: "section"
                 text:

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -81,11 +81,7 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"      
+            text: "*GitHub Action build result*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
 
       #----------------------------------------------
       #       check out repo

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -81,7 +81,7 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "*${{ github.event.repository.name }}*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+            text: "*${{ github.event.repository.name }}*: ${{ job.status }}\noh no\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
 
       #----------------------------------------------
       #       check out repo

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -181,4 +181,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "⚠️*${{ job.status }}*\n[${{ github.event.repository.name }}, ${{ matrix.os }}, Python ${{ matrix.python-version }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            text: "⚠️*${{ job.status }}*\n[${{ github.event.repository.name }}, ${{ matrix.os }}, Python ${{ matrix.python-version }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job.id }})"

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -53,6 +53,11 @@ on:
         required: false
         type: boolean
         default: false
+      slack-error:
+        description: Post error message to Slack on build failure
+        required: false
+        type: boolean
+        default: false
 
 
 jobs:
@@ -74,14 +79,6 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
     steps:
-
-      - name: Post a message in a channel
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "*${{ github.event.repository.name }}*: ${{ job.status }}\noh no\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
 
       #----------------------------------------------
       #       check out repo
@@ -173,3 +170,15 @@ jobs:
           verbose: true
           env_vars: OS,PYTHON
           fail_ci_if_error: ${{ inputs.fail-on-codecov-error }}
+
+      #----------------------------------------------
+      #       Post error msg to Slack
+      #----------------------------------------------        
+      - name: Post a Slack message if build failed
+        uses: slackapi/slack-github-action@v2.0.0
+        if: failure()
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "*${{ github.event.repository.name }}*: ${{ job.status }}\n ${{ matrix.os }}, Python ${{ matrix.python-version }}"          

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -181,4 +181,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "*${{ github.event.repository.name }}*: ${{ job.status }}\n ${{ matrix.os }}, Python ${{ matrix.python-version }}"          
+            text: "⚠️*${{ github.event.repository.name }}*: ${{ job.status }}\n${{ matrix.os }}, Python ${{ matrix.python-version }}"          

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -181,4 +181,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "⚠️*${{ github.event.repository.name }}*: ${{ job.status }}\n${{ matrix.os }}, Python ${{ matrix.python-version }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: "⚠️*${{ job.status }}*\n[${{ github.event.repository.name }}, ${{ matrix.os }}, Python ${{ matrix.python-version }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -181,4 +181,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "⚠️*${{ job.status }}*\n[${{ github.event.repository.name }}, ${{ matrix.os }}, Python ${{ matrix.python-version }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job.id }})"
+            text: "⚠️*${{ job.status }}*\n[${{ github.event.repository.name }}, ${{ matrix.os }}, Python ${{ matrix.python-version }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job }})"

--- a/samplePythonProject/tests/test_basic.py
+++ b/samplePythonProject/tests/test_basic.py
@@ -1,2 +1,2 @@
 def test_example():
-    assert 1 + 1 == 3
+    assert 1 + 1 == 2

--- a/samplePythonProject/tests/test_basic.py
+++ b/samplePythonProject/tests/test_basic.py
@@ -1,2 +1,2 @@
 def test_example():
-    assert 1 + 1 == 2
+    assert 1 + 1 == 3


### PR DESCRIPTION
Closes #9

If a scheduled build fails, this message will be sent to the `cwg-scheduled-builds` Slack channel:

![image](https://github.com/user-attachments/assets/7facc441-af6d-4a92-a5e7-b27bc752617d)

For this to work, each repo will have to have a `SCHEDULED_GITHUB_SLACK_WEBHOOK` secret.
